### PR TITLE
added regex to check for an 's' in the http precursor of import url

### DIFF
--- a/src/APIClientLibrary/XMLHandler.php
+++ b/src/APIClientLibrary/XMLHandler.php
@@ -25,7 +25,7 @@ class XMLHandler {
 	 * @return XMLHandler
 	 */
 	function __construct($url){
-	 if(!preg_match('/^http:\/\//', $url)){
+	 if(!preg_match('/^https?:\/\//', $url)){
       $url = 'file://' . $url;
     }
 


### PR DESCRIPTION
Here's the fix to the import url for the XML handler @dking3876 